### PR TITLE
Several bug fixes and enhancements

### DIFF
--- a/usr.sbin/relayd/check_icmp.c
+++ b/usr.sbin/relayd/check_icmp.c
@@ -246,7 +246,7 @@ send_icmp(int s, short event, void *arg)
 					    0) == 0) {
 						if (setsockopt(s, IPPROTO_IP,
 						    IP_TTL, &ttl,
-						    sizeof(ttl) == -1))
+						    sizeof(ttl)) == -1)
 							log_warn(
 							    "%s: setsockopt",
 							    __func__);

--- a/usr.sbin/relayd/check_icmp.c
+++ b/usr.sbin/relayd/check_icmp.c
@@ -237,17 +237,20 @@ send_icmp(int s, short event, void *arg)
 				} else {
 					/* Revert to default TTL */
 #ifdef __FreeBSD__
-				mib[0] = CTL_NET;
-				mib[1] = cie->af;
-				mib[2] = IPPROTO_IP;
-				mib[3] = IPCTL_DEFTTL;
-				len = sizeof(ttl);
-				if (sysctl(mib, 4, &ttl, &len, NULL, 0) == 0)
-					if (setsockopt(s, IPPROTO_IP, IP_TTL,
-					    &ttl, sizeof(ttl) == -1))
-						log_warn(
-						    "%s: setsockopt",
-						    __func__);
+					mib[0] = CTL_NET;
+					mib[1] = cie->af;
+					mib[2] = IPPROTO_IP;
+					mib[3] = IPCTL_DEFTTL;
+					len = sizeof(ttl);
+					if (sysctl(mib, 4, &ttl, &len, NULL,
+					    0) == 0) {
+						if (setsockopt(s, IPPROTO_IP,
+						    IP_TTL, &ttl,
+						    sizeof(ttl) == -1))
+							log_warn(
+							    "%s: setsockopt",
+							    __func__);
+					}
 #else
 					len = sizeof(ttl);
 					if (getsockopt(s, IPPROTO_IP,

--- a/usr.sbin/relayd/check_script.c
+++ b/usr.sbin/relayd/check_script.c
@@ -48,6 +48,7 @@ check_script(struct relayd *env, struct host *host)
 	host->flags &= ~(F_CHECK_SENT|F_CHECK_DONE);
 
 	scr.host = host->conf.id;
+	scr.config_gen = env->sc_config_gen;
 	if ((strlcpy(scr.name, host->conf.name,sizeof(scr.name)) >=
 	    sizeof(scr.name)) ||
 	    (strlcpy(scr.path, table->conf.path, sizeof(scr.path)) >=
@@ -64,6 +65,12 @@ void
 script_done(struct relayd *env, struct ctl_script *scr)
 {
 	struct host		*host;
+
+	if (scr->config_gen != env->sc_config_gen) {
+		log_debug("script check for %s interrupted, ignoring",
+		    scr->name);
+		return;
+	}
 
 	if ((host = host_find(env, scr->host)) == NULL)
 		fatalx("%s: invalid host id", __func__);

--- a/usr.sbin/relayd/config.c
+++ b/usr.sbin/relayd/config.c
@@ -153,6 +153,8 @@ config_purge(struct relayd *env, u_int reset)
 	struct keyname		*keyname;
 	u_int			 what;
 
+	env->sc_started = 0;
+
 	what = ps->ps_what[privsep_process] & reset;
 
 	if (what & CONFIG_TABLES && env->sc_tables != NULL) {
@@ -264,6 +266,8 @@ config_getreset(struct relayd *env, struct imsg *imsg)
 	memcpy(&mode, imsg->data, sizeof(mode));
 
 	config_purge(env, mode);
+
+	env->sc_config_gen++;
 
 	return (0);
 }

--- a/usr.sbin/relayd/parse.y
+++ b/usr.sbin/relayd/parse.y
@@ -537,7 +537,7 @@ rdr		: REDIRECT STRING	{
 			if (strlcpy(srv->conf.name, $2,
 			    sizeof(srv->conf.name)) >=
 			    sizeof(srv->conf.name)) {
-				yyerror("redirection name truncated");
+				yyerror("redirection name truncated: %s", $2);
 				free($2);
 				free(srv);
 				YYERROR;
@@ -673,7 +673,8 @@ rdroptsl	: forwardmode TO tablespec interface	{
 			if (strlcpy(rdr->conf.tag, $3,
 			    sizeof(rdr->conf.tag)) >=
 			    sizeof(rdr->conf.tag)) {
-				yyerror("redirection tag name truncated");
+				yyerror("redirection tag name truncated: %s",
+				    $3);
 				free($3);
 				YYERROR;
 			}

--- a/usr.sbin/relayd/parse.y
+++ b/usr.sbin/relayd/parse.y
@@ -175,11 +175,7 @@ typedef struct {
 		struct {
 			struct sockaddr_storage	 ss;
 			int			 prefixlen;
-#ifdef __FreeBSD__
-			char			 name[MAXHOSTNAMELEN];
-#else
 			char			 name[HOST_NAME_MAX+1];
-#endif
 		}			 addr;
 		struct {
 			enum digest_type type;

--- a/usr.sbin/relayd/pfe_route.c
+++ b/usr.sbin/relayd/pfe_route.c
@@ -56,11 +56,7 @@ sync_routes(struct relayd *env, struct router *rt)
 {
 	struct netroute		*nr;
 	struct host		*host;
-#ifdef __FreeBSD__
-	char			 buf[MAXHOSTNAMELEN];
-#else
 	char			 buf[HOST_NAME_MAX+1];
-#endif
 	struct ctl_netroute	 crt;
 
 	if (!(env->sc_conf.flags & F_NEEDRT))

--- a/usr.sbin/relayd/relay.c
+++ b/usr.sbin/relayd/relay.c
@@ -1976,6 +1976,8 @@ relay_dispatch_pfe(int fd, struct privsep_proc *p, struct imsg *imsg)
 	case IMSG_HOST_STATUS:
 		IMSG_SIZE_CHECK(imsg, &st);
 		memcpy(&st, imsg->data, sizeof(st));
+		if (st.config_gen != env->sc_config_gen)
+			break;
 		if ((host = host_find(env, st.id)) == NULL)
 			fatalx("%s: invalid host id", __func__);
 		if (host->flags & F_DISABLE)

--- a/usr.sbin/relayd/relay_http.c
+++ b/usr.sbin/relayd/relay_http.c
@@ -1015,11 +1015,7 @@ relay_lookup_url(struct ctl_relay_event *cre, const char *host, struct kv *kv)
 	struct http_descriptor	*desc = (struct http_descriptor *)cre->desc;
 	int			 i, j, dots;
 	char			*hi[RELAY_MAXLOOKUPLEVELS], *p, *pp, *c, ch;
-#ifdef __FreeBSD__
-	char			 ph[MAXHOSTNAMELEN];
-#else
 	char			 ph[HOST_NAME_MAX+1];
-#endif
 	int			 ret;
 
 	if (desc->http_path == NULL)

--- a/usr.sbin/relayd/relayd.h
+++ b/usr.sbin/relayd/relayd.h
@@ -79,9 +79,7 @@
 #define LABEL_NAME_SIZE		1024
 #define TAG_NAME_SIZE		64
 #define TABLE_NAME_SIZE		64
-#define	RD_TAG_NAME_SIZE	64
 #define	RT_LABEL_SIZE		32
-#define SRV_NAME_SIZE		64
 #define MAX_NAME_SIZE		64
 #define SRV_MAX_VIRTS		16
 #define TLS_NAME_SIZE		512
@@ -585,8 +583,8 @@ struct rdr_config {
 	objid_t			 backup_id;
 	int			 mode;
 	union hashkey		 key;
-	char			 name[SRV_NAME_SIZE];
-	char			 tag[RD_TAG_NAME_SIZE];
+	char			 name[PF_TABLE_NAME_SIZE];
+	char			 tag[PF_TAG_NAME_SIZE];
 	struct timeval		 timeout;
 };
 

--- a/usr.sbin/relayd/relayd.h
+++ b/usr.sbin/relayd/relayd.h
@@ -162,6 +162,7 @@ struct ctl_status {
 	int		 up;
 	int		 retry_cnt;
 	u_long		 check_cnt;
+	u_int64_t	 config_gen;
 	u_int16_t	 he;
 };
 
@@ -193,6 +194,7 @@ struct ctl_relayfd {
 
 struct ctl_script {
 	objid_t		 host;
+	u_int64_t	 config_gen;
 	int		 retval;
 	struct timeval	 timeout;
 	char		 name[HOST_NAME_MAX+1];
@@ -481,6 +483,7 @@ struct host {
 	u_long			 up_cnt;
 	int			 retry_cnt;
 	int			 idx;
+	u_int64_t		 config_gen;
 	u_int16_t		 he;
 	int			 code;
 	struct ctl_tcp_event	 cte;
@@ -1059,7 +1062,7 @@ enum imsg_type {
 	IMSG_CA_PRIVDEC,
 	IMSG_SESS_PUBLISH,	/* from relay to pfe */
 	IMSG_SESS_UNPUBLISH,
-	IMSG_TLSTICKET_REKEY
+	IMSG_TLSTICKET_REKEY,
 };
 
 enum privsep_procid {
@@ -1206,6 +1209,8 @@ struct relayd {
 
 	struct privsep		*sc_ps;
 	int			 sc_reload;
+	int			 sc_started;
+	u_int64_t		 sc_config_gen;
 };
 
 #define RELAYD_OPT_VERBOSE		0x01

--- a/usr.sbin/relayd/relayd.h
+++ b/usr.sbin/relayd/relayd.h
@@ -147,6 +147,10 @@
 #define DPRINTF(x...)	do {} while(0)
 #endif
 
+#ifdef __FreeBSD__
+#define	HOST_NAME_MAX		(MAXHOSTNAMELEN - 1)
+#endif
+
 /* Used for DNS request ID randomization */
 struct shuffle {
 	u_int16_t	 id_shuffle[65536];
@@ -193,11 +197,7 @@ struct ctl_script {
 	objid_t		 host;
 	int		 retval;
 	struct timeval	 timeout;
-#ifdef __FreeBSD__
-	char		 name[MAXHOSTNAMELEN];
-#else
 	char		 name[HOST_NAME_MAX+1];
-#endif
 	char		 path[PATH_MAX];
 };
 
@@ -463,11 +463,7 @@ struct host_config {
 	objid_t			 parentid;
 	objid_t			 tableid;
 	int			 retry;
-#ifdef __FreeBSD__
-	char			 name[MAXHOSTNAMELEN];
-#else
 	char			 name[HOST_NAME_MAX+1];
-#endif
 	struct sockaddr_storage	 ss;
 	int			 ttl;
 	int			 priority;
@@ -847,11 +843,7 @@ struct relay_config {
 	objid_t			 id;
 	u_int32_t		 flags;
 	objid_t			 proto;
-#ifdef __FreeBSD__
-	char			 name[MAXHOSTNAMELEN];
-#else
 	char			 name[HOST_NAME_MAX+1];
-#endif
 	in_port_t		 port;
 	in_port_t		 dstport;
 	int			 dstretry;
@@ -929,11 +921,7 @@ TAILQ_HEAD(netroutelist, netroute);
 struct router_config {
 	objid_t			 id;
 	u_int32_t		 flags;
-#ifdef __FreeBSD__
-	char			 name[MAXHOSTNAMELEN];
-#else
 	char			 name[HOST_NAME_MAX+1];
-#endif
 	char			 label[RT_LABEL_SIZE];
 	int			 nroutes;
 	objid_t			 gwtable;


### PR DESCRIPTION
- Fix a problem wherein relayd would exit with an assertion failure shortly after a config reload (triggered by SIGHUP or `relayctl reload`).
- Make sure that excessively long table names are caught by `relayd -n` instead of at daemon start time.
- In host status log messages, include the port number when applicable. This makes troubleshooting easier when using relayd to manage multiple services on the same host.
- Fix a minor FreeBSD-specific bug in the handling of the TTL for ICMP checks.
- Slightly reduce the FreeBSD diff.

Sponsored by: Klara, Inc.
Sponsored by: Modirum