### PR TITLE
freebsd-relayd: Update ifdefs for SO_SPLICE support

### DIFF
--- a/usr.sbin/relayd/relay_http.c
+++ b/usr.sbin/relayd/relay_http.c
@@ -724,7 +724,7 @@ relay_read_http(struct bufferevent *bev, void *arg)
 		relay_close(con, "last http read (done)", 0);
 		return;
 	}
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) || defined(SO_SPLICE)
 	switch (relay_splice(cre)) {
 	case -1:
 		relay_close(con, strerror(errno), 1);
@@ -764,7 +764,7 @@ relay_read_httpcontent(struct bufferevent *bev, void *arg)
 	    con->se_id, size, cre->toread);
 	if (!size)
 		return;
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) || defined(SO_SPLICE)
 	if (relay_spliceadjust(cre) == -1)
 		goto fail;
 #endif
@@ -827,7 +827,7 @@ relay_read_httpchunks(struct bufferevent *bev, void *arg)
 	    con->se_id, size, cre->toread);
 	if (!size)
 		return;
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) || defined(SO_SPLICE)
 	if (relay_spliceadjust(cre) == -1)
 		goto fail;
 #endif


### PR DESCRIPTION
relayd is a useful vehicle for testing SO_SPLICE. Start compiling splice support by default when compiled against a tree that implements SO_SPLICE. See https://reviews.freebsd.org/D46411 for a bit more background.

I did some basic testing to verify that TCP and HTTP proxying with SO_SPLICE works properly.