### PR TITLE
siphash.c: fix build on big-endian

### DIFF
--- a/usr.sbin/relayd/siphash.c
+++ b/usr.sbin/relayd/siphash.c
@@ -64,8 +64,8 @@ SipHash_Init(SIPHASH_CTX *ctx, const SIPHASH_KEY *key)
 	uint64_t k0, k1;
 
 #ifdef __FreeBSD__
-	k0 = le64toh(&key->k0);
-	k1 = le64toh(&key->k1);
+	k0 = le64toh(key->k0);
+	k1 = le64toh(key->k1);
 #else
 	k0 = lemtoh64(&key->k0);
 	k1 = lemtoh64(&key->k1);
@@ -191,7 +191,7 @@ void
 SipHash_CRounds(SIPHASH_CTX *ctx, int rounds)
 {
 #ifdef __FreeBSD__
-	u_int64_t m = le64toh((u_int64_t *)ctx->buf);
+	u_int64_t m = le64toh((u_int64_t)ctx->buf);
 #else
 	u_int64_t m = lemtoh64((u_int64_t *)ctx->buf);
 #endif


### PR DESCRIPTION
```
siphash.c:67:7: error: incompatible pointer to integer conversion passing 'const u_int64_t *' (aka 'const unsigned long *') to parameter of type 'unsigned long' [-Wint-conversion]
   67 |         k0 = le64toh(&key->k0);
      |              ^~~~~~~~~~~~~~~~~
/usr/include/sys/_endian.h:130:30: note: expanded from macro 'le64toh'
  130 | #define le64toh(x)      __bswap64((x))
      |                         ~~~~~~~~~~^~~~
/usr/include/sys/_endian.h:85:40: note: expanded from macro '__bswap64'
   85 | #define __bswap64(x)    __builtin_bswap64(x)
      |                                           ^
siphash.c:68:7: error: incompatible pointer to integer conversion passing 'const u_int64_t *' (aka 'const unsigned long *') to parameter of type 'unsigned long' [-Wint-conversion]
   68 |         k1 = le64toh(&key->k1);
      |              ^~~~~~~~~~~~~~~~~
/usr/include/sys/_endian.h:130:30: note: expanded from macro 'le64toh'
  130 | #define le64toh(x)      __bswap64((x))
      |                         ~~~~~~~~~~^~~~
/usr/include/sys/_endian.h:85:40: note: expanded from macro '__bswap64'
   85 | #define __bswap64(x)    __builtin_bswap64(x)
      |                                           ^
siphash.c:194:16: error: incompatible pointer to integer conversion passing 'u_int64_t *' (aka 'unsigned long *') to parameter of type 'unsigned long'; dereference with * [-Wint-conversion]
  194 |         u_int64_t m = le64toh((u_int64_t *)ctx->buf);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/_endian.h:130:30: note: expanded from macro 'le64toh'
  130 | #define le64toh(x)      __bswap64((x))
      |                         ~~~~~~~~~~^~~~
/usr/include/sys/_endian.h:85:40: note: expanded from macro '__bswap64'
   85 | #define __bswap64(x)    __builtin_bswap64(x)
      |                                           ^
3 errors generated.
```